### PR TITLE
Reversed variable names to get icap response line (name, value)

### DIFF
--- a/ICAPResponse.c
+++ b/ICAPResponse.c
@@ -37,9 +37,9 @@ py_resp_add_header(void *data, char const *name, char const *value)
     py_resp_headers_ctx *ctx = data;
 
     if(ctx->idx == 0 &&
-       (value == NULL || *value == '\0'))
+       (name == NULL || *name == '\0'))
     {
-	ctx->line = PyString_FromString(name);
+	ctx->line = PyString_FromString(value);
     }
     else
     {


### PR DESCRIPTION
According to my tests the module failed when calling conn.getresponse() in Python:
```Python
>>> resp = conn.getresponse()
 Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 icapclient.ICAPException: Cannot parse the ICAP response line
```
This happened because the two variable names (name and value) have been reversed.
After exchanging them, placing "name" in the if statement and "value" where "line" is assigned it worked.
Here a working sample output with some debug info:
```Python
>>> import icapclient
>>> conn = icapclient.ICAPConnection('xxx.xxx.xxx.xxx')
>>> conn.request('REQMOD', '/tmp/test.txt')
>>> resp = conn.getresponse()
idx: '0', name: '', value: 'ICAP/1.0 204 No modifications needed'
idx: '1', name: 'X-Apparent-Data-Types', value: 'ASCII'
idx: '2', name: 'X-ICAP-Metadata', value: '{ "expect_sandbox": false }'
idx: '3', name: 'Service', value: 'CAS 1.3.7.1(190497)'
idx: '4', name: 'Service-ID', value: 'avscanner'
idx: '5', name: 'ISTag', value: '"58C0DCDA"'
idx: '6', name: 'Encapsulated', value: 'null-body=0'
idx: '7', name: 'Date', value: 'Thu, 09 Mar 2017 07:20:12 GMT'
line: 'ICAP/1.0 204 No modifications needed'
idx: '0', name: '', value: 'POST / HTTP/1.1'
idx: '1', name: 'Host', value: 'localhost'
idx: '2', name: 'Transfer-Encoding', value: 'chunked'
>>> conn.close()
>>>
```
To get the ICAP response line we have to check against the empty name variable, if this is true we assign the "value" variable: `idx: '0', name: '', value: 'ICAP/1.0 204 No modifications needed'`